### PR TITLE
Add act model as separate model

### DIFF
--- a/src/cellular_potts/act.cpp
+++ b/src/cellular_potts/act.cpp
@@ -1,0 +1,117 @@
+#include <act.hpp>
+#include <cmath>
+#include <iostream>
+#include <parameter.hpp>
+#include <vector>
+extern Parameter par;
+
+using namespace ACT;
+namespace
+{
+    /**
+     * @brief Computes the geometric mean of the ACT values of all pixel with
+     * the same spin as the spin of the position argument.
+     * @param act_field
+     * @param sigma the CPM grid used
+     * @param pos The position on which the mean is computed
+     * @warning Ensure that pos is a valid position in the bounds of sigma.
+     * @return The geometric mean.
+     */
+    double GeoMetricMean(ActField const &act_field, int **sigma, PixelPos pos)
+    {
+        // NO BOUNDS CHECK for sigma
+        int mainspin = sigma[pos.x][pos.y];
+        double output = 1.0;
+        int count = 0;
+        for (int i = -1; i <= 1; i++)
+            for (int j = -1; j <= 1; j++)
+            {
+                PixelPos neighbour_pos(i, j);
+                neighbour_pos += pos;
+                if (sigma[neighbour_pos.x][neighbour_pos.y] == mainspin)
+                {
+                    double value = act_field.Value(neighbour_pos);
+                    if (value <= 0.0)
+                    {
+                        return 0.0;
+                    }
+                    count++;
+                    output *= value;
+                }
+            }
+        if (count == 0.0)
+            return 0.0;
+        return std::pow(output, 1.0 / count);
+    }
+}
+
+void ActField::IncreaseValue(PixelPos pos, double value)
+{
+    value_[pos] += value;
+}
+
+double ActField::Value(PixelPos pos) const
+{
+    auto it = value_.find(pos);
+    if (it != value_.end()) // If found, note: value_.end() points to the
+                            // element past the last element.
+    {
+        return it->second;
+    }
+    return 0.0;
+}
+
+void ActField::SetValue(PixelPos pos, double value)
+{
+    if (value > 0.0)
+        value_[pos] = value;
+    else
+    {
+        value_.erase(pos);
+    }
+}
+
+void ActField::Decrease()
+{
+    auto it = value_.begin();
+    while (it != value_.end())
+    {
+        it->second -= 1.0;
+        if (it->second <= 0.0)
+        {
+            it = value_.erase(it);
+        }
+        else
+        {
+            it++;
+        }
+    }
+}
+
+double ACT::DeltaH(ActField const &act_field, int **sigma, PixelPos from,
+                   PixelPos to, double const lambda_act, double const max_Act)
+{
+    double GM_source = GeoMetricMean(act_field, sigma, from);
+
+    // If medium has positive act, something went wrong somewhere. It is catched here.
+    if (sigma[from.x][from.y] == 0 && GM_source > 0)
+        throw std::runtime_error("from medium has positive act!!");
+
+    double GM_target = GeoMetricMean(act_field, sigma, to);
+    if (sigma[to.x][to.y] == 0 && GM_target > 0)
+        throw std::runtime_error("to medium has positive act!!");
+
+    return (lambda_act / max_Act) * (GM_source - GM_target);
+}
+
+void ACT::commit_move(ActField &act_field, int **sigma, PixelPos from,
+                      PixelPos to)
+{
+    if (sigma[from.x][from.y] > 0)
+    {
+        act_field.SetValue(to, par.max_Act);
+    }
+
+    if (sigma[from.x][from.y] == 0)
+        act_field.SetValue(to, 0);
+}

--- a/src/cellular_potts/act.hpp
+++ b/src/cellular_potts/act.hpp
@@ -1,0 +1,89 @@
+#pragma once
+#include <unordered_map>
+#include <vec2.hpp>
+
+namespace ACT
+{
+
+    /**
+     * Implementation of the ACT model (Niculescu et al., PLOS Comput Biol 2015)
+     *
+     * An instance of this class should be used to store the ACT field during a
+     * simulation. There are functions for accesing ACT values, and for the
+     * computation of the DeltaH used in the CPM simulation. After a MCS the
+     * ActField::Decrease() method should be called to decreas the ACT values by
+     * one. The function commit_move is used after a copy-attempt is accepted
+     * and it updates the values in the act field.
+     *
+     */
+    class ActField
+    {
+    public:
+        /** Get the actin value of a pixel. If pixel is not alive returns 0.0
+         *
+         *  @param Position
+         *  @return Value of actin level, or 0.0 if value was not inialized.
+         */
+        double Value(PixelPos) const;
+
+        /** Sets actin value of a pixel.
+         *
+         * This function is not needed to implement the orginal ACT model.
+         * However, there are instances when we want to model different actions
+         * to influence the ACT field e.g. see Daipengs thesis.
+         *
+         * @param pos Pixel to be set
+         * @param value Value too which this pixel is set.
+         */
+        void SetValue(PixelPos pos, double value);
+
+        /** Increase the value at pos by a positive value.
+         *
+         *  Increases the act value at position pos with value.
+         *  @param pos Position where act should be increased.
+         *  @param value The positive value with which act is increased.
+         *  @warning Is a negative value is used, the act value can be negative.
+         *  I don't know what happends then..
+         */
+        void IncreaseValue(PixelPos pos, double value);
+
+        /** Decreases the act value of all pixels with 1. Removes the
+         *  pixel if act value is 0
+         */
+        void Decrease();
+
+        /** Method used for testing
+         */
+        friend std::unordered_map<PixelPos, double> getValue(ActField);
+
+    private:
+        std::unordered_map<PixelPos, double> value_;
+    };
+
+    /** Compute the deltaH that should be substracted from the DH.
+     *
+     *  @param act_field Actin field which values should be used.
+     *  @param sigma The spin configuration that should be used.
+     *  @param from The source pixel
+     *  @param to The target pixel
+     *  @param lambda_act Lambda value to use.
+     *  @param max_act Maxium Actin value.
+     *  @return DeltaH contribution, should be substracted from the total
+     *  hamiltonian to give a discount for high act movements.
+     */
+    double DeltaH(ActField const &act_field, int **sigma, PixelPos from,
+                  PixelPos to, double const lambda_act, double const max_act);
+
+    /** Commit a move. If the move is an extension (spin of target > 0),
+     *  sets the act value of the target to maxact. Should be called after a
+     *  copy-attempt is accepted.
+     *
+     *  @param act_field The act field to which the copy-attempt should be
+     *  registered.
+     *  @param sigma The spin field used.
+     *  @param from The source pixel
+     *  @param to The target pixel.
+     */
+    void commit_move(ActField &act_field, int **sigma, PixelPos from,
+                     PixelPos to);
+}

--- a/src/cellular_potts/tests/Makefile
+++ b/src/cellular_potts/tests/Makefile
@@ -15,6 +15,7 @@ ifneq "$(filter $(MAKECMDGOALS),clean)" "clean"
     CXXFLAGS += -I. -I.. -I../.. -I../../graphics -I../../models
     CXXFLAGS += -I../../parameters -I../../plotting -I../../reaction_diffusion
     CXXFLAGS += -I../../util -I../../xpm -I../../compute
+    CXXFLAGS += -I../../spatial -I../../parameters
     CXXFLAGS += -I../../../lib/MultiCellDS/v1.0/v1.0.0/libMCDS/mcds_api/
     CXXFLAGS += -I../../../lib/MultiCellDS/v1.0/v1.0.0/libMCDS/xsde/libxsde
     LDFLAGS := $(CATCH2_LIBS) $(LDFLAGS)

--- a/src/cellular_potts/tests/mock_parameter.hpp
+++ b/src/cellular_potts/tests/mock_parameter.hpp
@@ -1,0 +1,11 @@
+
+class MockParameter {
+    public:
+        double lambda_Act;
+        double max_Act;
+    
+};
+
+MockParameter par;
+
+using Parameter = MockParameter;

--- a/src/cellular_potts/tests/test_act.cpp
+++ b/src/cellular_potts/tests/test_act.cpp
@@ -1,0 +1,157 @@
+#define _MOCK_PARAMETER_HPP_ "mock_parameter.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "act.cpp"
+
+using Catch::Matchers::WithinAbs;
+std::unordered_map<PixelPos, double> ACT::getValue(ACT::ActField act_field) {
+    return act_field.value_;
+}
+TEST_CASE("Act Model")
+{
+    SECTION("Setting and Getting values")
+    {
+        ACT::ActField act_field;
+
+        act_field.SetValue({0, 0}, 1.0);
+        auto value = act_field.Value({0, 0});
+        REQUIRE_THAT(value, WithinAbs(1.0, 0.00001));
+
+        act_field.Decrease();
+
+        value = act_field.Value({0, 0});
+        REQUIRE_THAT(value, WithinAbs(0.0, 0.00001));
+
+        // REQUIRE_THROWS_AS(act_field.Value({1, 0}), std::out_of_range);
+        REQUIRE_THAT(act_field.Value({1,0}), WithinAbs(0.0, 0.00001) );
+    }
+    SECTION("Create ActField and get geo mean of point")
+    {
+        ACT::ActField act_field;
+        
+        int** sigma = new int*[4];
+        sigma[0] = new int[4]; 
+        sigma[1] = new int[4]; 
+        sigma[2] = new int[4]; 
+        sigma[3] = new int[4]; 
+        
+        for (int i=0; i<4; i++)
+        for (int j=0; j<4; j++)
+            sigma[i][j]=0;
+
+        act_field.SetValue({1+0,  1+0}, 1.0);
+        act_field.SetValue({1+1,  1+0}, 1.0);
+        act_field.SetValue({1+1,  1+1}, 1.0);
+        act_field.SetValue({1+0,  1+1}, 1.0);
+        act_field.SetValue({1+-1, 1+1}, 1.0);
+        act_field.SetValue({1+-1, 1+0}, 1.0);
+        act_field.SetValue({1+-1, 1+-1}, 1.0);
+        act_field.SetValue({1+0, 1+-1}, 1.0);
+        act_field.SetValue({1+1, 1+-1}, 1.0);
+
+        auto mean = GeoMetricMean(act_field, sigma, {1, 1});
+        REQUIRE_THAT(mean, WithinAbs(1.0, 0.00001));
+
+        act_field.SetValue({1+0,  1+0}, 1.0);
+        act_field.SetValue({1+1,  1+0}, 2.0);
+        act_field.SetValue({1+1,  1+1}, 3.0);
+        act_field.SetValue({1+0,  1+1}, 4.0);
+        act_field.SetValue({1+-1, 1+1}, 5.0);
+        act_field.SetValue({1+-1, 1+0}, 6.0);
+        act_field.SetValue({1+-1, 1+-1}, 7.0);
+        act_field.SetValue({1+0, 1+-1}, 8.0);
+        act_field.SetValue({1+1, 1+-1}, 9.0);
+
+        mean = GeoMetricMean(act_field,sigma, {1, 1});
+        REQUIRE_THAT(mean, WithinAbs(4.147166274396913, 0.00000001));
+    }
+    
+    SECTION("Delta H") {
+        // This example is straight from the orginal paper.
+
+        ACT::ActField act_field;
+        
+        par.lambda_Act = 1.0;
+        par.max_Act = 20;
+        
+//        const int sigma_array[4][4] = {
+//            {0,0,1,1},
+//            {0,0,1,1},
+//            {2,2,0,0},
+//            {2,2,2,0},
+//        };
+
+        int** sigma = new int*[4];
+        sigma[0] = new int[4]; 
+        sigma[1] = new int[4]; 
+        sigma[2] = new int[4]; 
+        sigma[3] = new int[4]; 
+        
+        for (int i=0; i<4; i++)
+        for (int j=0; j<4; j++)
+            sigma[i][j]=0;
+        
+        sigma[2][0] = 1;
+        sigma[3][0] = 1;
+        sigma[2][1] = 1;
+        sigma[3][1] = 1;
+        sigma[0][2] = 2;
+        sigma[1][2] = 2;
+        sigma[0][3] = 2;
+        sigma[1][3] = 2;
+        sigma[2][3] = 2;
+
+        act_field.SetValue({2,0}, 19);
+        act_field.SetValue({3,0}, 11);
+        act_field.SetValue({2,1}, 17);
+        act_field.SetValue({3,1}, 16);
+        act_field.SetValue({0,2}, 18);
+        act_field.SetValue({1,2}, 20);
+        act_field.SetValue({0,3}, 15);
+        act_field.SetValue({1,3}, 17);
+        act_field.SetValue({2,3}, 15);
+
+        auto GM_v = GeoMetricMean(act_field, sigma, {2,1});
+        auto GM_u = GeoMetricMean(act_field, sigma, {1,2});
+
+        auto dh = ACT::DeltaH(act_field, sigma, {1,2}, {2,1}, par.lambda_Act, par.max_Act); 
+
+        REQUIRE_THAT(dh * par.max_Act, WithinAbs(1.46 , 0.01));
+    }
+    SECTION ("Test decreasing and deleting of positions") {
+        ACT::ActField actin_field;
+        
+        actin_field.SetValue({10,10}, 10);
+        for (int i=0; i < 5; i++)
+            actin_field.Decrease();
+        REQUIRE(actin_field.Value({10,10}) == 5);
+
+        for (int i=0; i < 5; i++)
+            actin_field.Decrease();
+        REQUIRE(actin_field.Value({10,10}) == 0.0);
+
+        auto values = getValue(actin_field);
+        REQUIRE( values.size() == 0);
+        
+        actin_field.SetValue({20, 10}, 10.0);
+        values = getValue(actin_field);
+        REQUIRE( values.size() == 1);
+
+        actin_field.SetValue({20, 10}, 0.0);
+        values = getValue(actin_field);
+        REQUIRE( values.size() == 0);
+        
+    }
+    SECTION ("Adding value to act") {
+        ACT::ActField act_field;
+
+        act_field.SetValue({10,10}, 10);
+        act_field.IncreaseValue({10,10}, 5);
+        auto value = act_field.Value({10,10});
+        REQUIRE( value == 15 );
+        act_field.IncreaseValue({5,5}, 123);
+        value = act_field.Value({5,5});
+        REQUIRE( value == 123);
+    }
+}


### PR DESCRIPTION
# Introduction

The act model that is implemented currently in the TST is heavily interwoven with some adhesion code that was used for a specific publication. When I wanted to use the act model it was unclear how to remove the adhesion part and just keep the act part. This piece of code abstracts away the act model in a single file which can be included in ca.hpp and ca.cpp to apply  when someone wants to use the act model. 

# How to use this code

The included files implement the act model, however you still need to couple it to you already existing model.

In ca.hpp include act.hpp in the top of the file. Next add an instance of the ActField class to the CellularPotts class. Now there are three places where you should link the two classes. In AmoebaeMove add a call to ACT::ActField::Decrease() at the end of the method and add a ACT::ActField::commit_move(...) in the place where copy-attempts get accepted. Finally add the ACT::DeltaH function somewhere into the CellularPotts::DeltaH function. 

