### PR TITLE
Update GitHub repository URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ To get the source, clone the repository from GitHub:
 
 .. code-block:: bash
 
-    git clone --recursive -b TST2.0 git@github.com:rmerks/Tissue-Simulation-Toolkit.git
+    git clone --recursive -b TST2.0 git@github.com:mathbioleiden/Tissue-Simulation-Toolkit.git
 
 The TST can then be built using
 


### PR DESCRIPTION
Just a small URL update I came across when setting up the project: `github.com/rmerks/Tissue-Simulation-Toolkit` does not seem to exist anymore and the README of this repo should probably refer to this repo.